### PR TITLE
1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
-## [1.0.0] - 2 February 2020
+## [1.1.0] - 24 February 2021
+- New: `CornerstoneException`, a common exception model to make repository layer even more decoupled.
+- Update: Bump `json_serialization` dependency to `^3.1.1`
+
+## [1.0.0] - 2 February 2021
 - **Breaking:** `CornerstonePersistentRepositoryMixin`'s `loadData()` is now removed. You just need to add dependency of `convertToSnapshot` to persistent repository with `CornerstonePersistentRepositoryMixin`. The mixin now handles loading data, and assigning it to `repo.snapshot` (Means less code to write!). The snapshot is now named `snapshot`, and declared in the mixin (you can override it). If you want to use other names for snapshot, you need to override `load`. You can override `snapshot` if you want to assign default value to it (See `auto_persistent_people_repository.dart` in example).
 - First stable release of cornerstone! From now on, breaking changes will only introduced with new major version.
 
-## [0.1.2] - 20 January 2020
+## [0.1.2] - 20 January 2021
 - Revert: `LocallyPersistentRepository` is now an abstract class again. In dart, you can use an abstract class as a mixin, but you can't have your classes extends from a mixin. You can always implements a mixin, but it will lose some built-in implementation code (In this case, e.g. `storageName`). So by making it an abstract class again, it will give you more flexibility with nothing to give up. Therefore this revert will not breaking anything. _(In case you are wondering, This is not the case with `CornerstonePersistentRepositoryMixin`. If I make it an abstract and extends from `LocallyPersistentRepository`, then it can no longer be used as a mixin.)_
 - Documentation: `MultipleGetterPersisitentRepository` should be written as `CornerstonePersistentRepositoryMixin` on `ConvertToSnapshot`'s dartdoc.
 
-## [0.1.1] - 20 January 2020
+## [0.1.1] - 20 January 2021
 - **Breaking**: `LocallyPersistentRepository` is now a mixin.
 - New: `CornerstonePersistentRepositoryMixin` (was `HivePersistentRepositoryMixin` for a moment in 0.1.0) to easily add persistence functionality to your repos. Made possible using `Hive`.
 - New: `Hive` as a dependency for `CornerstonePersistentRepositoryMixin`.
@@ -14,9 +18,9 @@
 - New: `CornerstoneSnapshot`. You can use it as base class for your repositories. It have built-in convenience like timestamp.
 - New: Example project has been updated to also includes `CornerstonePersistentRepositoryMixin` usage.
 
-## [0.0.2] - 13 January 2020
+## [0.0.2] - 13 January 2021
 - More consistency: Call in `UseCase` now accepts `Param param` instead of `Params params`.
 - More flexibility: UseCase is now declared as `UseCase<F, Type, Param>`. This way, you can pick any `Failure` entity you want. You can always pass the provided `Failure` for convenience.
 
-## [0.0.1] - 13 January 2020
+## [0.0.1] - 13 January 2021
 - Initial release of Cornerstone

--- a/lib/src/core/cornerstone_exception.dart
+++ b/lib/src/core/cornerstone_exception.dart
@@ -1,0 +1,19 @@
+import 'package:equatable/equatable.dart';
+import 'package:meta/meta.dart';
+
+/// An exception to encapsulate other exceptions from data source layer or below
+/// to make repository layer even more decoupled. The fields of this class is
+/// identical to Failure for easier conversion in the repository.
+class CornerstoneException<T> extends Equatable implements Exception {
+  /// Name of the error. You can put anything here, but make sure to be as
+  /// consistent as possible to make it easier to maintain.
+  final String name;
+
+  /// You can put anything here
+  final T details;
+
+  const CornerstoneException({@required this.name, this.details});
+
+  @override
+  List<Object> get props => [name, details];
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cornerstone
 description: A library written in pure dart to help devs set up dart projects with a proper architecture without having to write a lot of boilerplate code. Inspired by clean architecture.
-version: 1.0.0
+version: 1.1.0
 repository: https://www.github.com/moseskarunia/cornerstone
 
 environment:
@@ -11,7 +11,7 @@ dependencies:
   dartz: ^0.9.1
   equatable: ^1.2.5
   hive: ^1.4.4
-  json_annotation: ^3.0.1
+  json_annotation: ^3.1.1
   meta: ^1.2.4
 
 dev_dependencies:  

--- a/test/src/core/cornerstone_exception_test.dart
+++ b/test/src/core/cornerstone_exception_test.dart
@@ -1,0 +1,15 @@
+import 'package:cornerstone/src/core/cornerstone_exception.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('CornerstoneException props', () {
+    final f = CornerstoneException<Map<String, dynamic>>(
+      name: 'TEST_ERROR',
+      details: <String, dynamic>{'message': 'Lorem ipsum'},
+    );
+    expect(f.props, [
+      'TEST_ERROR',
+      <String, dynamic>{'message': 'Lorem ipsum'},
+    ]);
+  });
+}


### PR DESCRIPTION
## [1.1.0] - 24 February 2021
- New: `CornerstoneException`, a common exception model to make repository layer even more decoupled.
- Update: Bump `json_serialization` dependency to `^3.1.1`